### PR TITLE
Update CDVContact.m

### DIFF
--- a/src/ios/CDVContact.m
+++ b/src/ios/CDVContact.m
@@ -1310,9 +1310,16 @@ static NSDictionary* org_apache_cordova_contacts_defaultFields = nil;
 {
     NSMutableArray* photos = nil;
 
-    if (ABPersonHasImageData(self.record)) {
-        CFIndex photoId = ABRecordGetRecordID(self.record);
-        CFDataRef photoData = ABPersonCopyImageData(self.record);
+    // http://stackoverflow.com/questions/10160750/ios-cant-get-persons-image
+    // can't get image from a ABRecordRef copy
+    ABRecordID contactID = ABRecordGetRecordID(self.record);
+    ABAddressBookRef addressBook = ABAddressBookCreate();
+    
+    ABRecordRef origContactRef = ABAddressBookGetPersonWithRecordID(addressBook, contactID);
+    
+    if (ABPersonHasImageData(origContactRef)) {
+        CFIndex photoId = ABRecordGetRecordID(origContactRef);
+        CFDataRef photoData = ABPersonCopyImageData(origContactRef);
         if (!photoData) {
             return nil;
         }


### PR DESCRIPTION
ABPersonHasImageData() and ABPersonCopyImageDataWithFormat() don't work as expected on ABRecordRef copies (since IOS5?).
So apply a simple fix proposed here: http://stackoverflow.com/questions/10160750/ios-cant-get-persons-image

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?


### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
